### PR TITLE
Add fz_compress_writer and fz_decompress_writer to C interface

### DIFF
--- a/cpp/libfz/src/femtozip.cpp
+++ b/cpp/libfz/src/femtozip.cpp
@@ -108,6 +108,17 @@ int fz_compress(void *model, const char *source, int source_len, char *dest, int
     return outstr.length();
 }
 
+int fz_compress_writer(void *model, const char *source, size_t source_len, int (*dest_writer)(const char *buf, size_t len, void *arg), void *arg) {
+    CompressionModel *m = reinterpret_cast<CompressionModel*>(model);
+    ostringstream out;
+    m->compress(source, source_len, out);
+    string outstr = out.str();
+    if (outstr.length() == 0) {
+      return 1;
+    }
+    return dest_writer(outstr.c_str(), outstr.length(), arg);
+}
+
 int fz_decompress(void *model, const char *source, int source_len, char *dest, int dest_capacity) {
     CompressionModel *m = reinterpret_cast<CompressionModel*>(model);
     ostringstream out;
@@ -118,6 +129,17 @@ int fz_decompress(void *model, const char *source, int source_len, char *dest, i
     }
     memcpy(dest, outstr.c_str(), outstr.length());
     return outstr.length();
+}
+
+int fz_decompress_writer(void *model, const char *source, size_t source_len, int (*dest_writer)(const char *buf, size_t len, void *arg), void *arg) {
+    CompressionModel *m = reinterpret_cast<CompressionModel*>(model);
+    ostringstream out;
+    m->decompress(source, source_len, out);
+    string outstr = out.str();
+    if (outstr.length() == 0) {
+      return 1;
+    }
+    return dest_writer(outstr.c_str(), outstr.length(), arg);
 }
 
 

--- a/cpp/libfz/src/femtozip.h
+++ b/cpp/libfz/src/femtozip.h
@@ -101,6 +101,17 @@ void fz_release_model(void *model);
 int fz_compress(void *model, const char *source, int source_len, char *dest, int dest_capacity);
 
 /*
+ * Attempts to compress 'source_len' bytes starting at 'source'.  'dest_writer'
+ * is called with a pointer to the destination buffer and it's length.  The
+ * pointer is valid only for the lifetime of 'dest_writer'.  Returns 0 on
+ * success, non zero if an error occurred.  Calling fz_decompress with the
+ * resulting buffer will return the original bytes.
+ *
+ * @see fz_decompress_writer.
+ */
+int fz_compress_writer(void *model, const char *source, size_t source_len, int (*dest_writer)(const char *buf, size_t len, void *arg), void *arg);
+
+/*
  * Attempts to dcompress 'source_len' bytes starting at 'source' into 'dest'
  * using the specified 'model'.  'dest_capacity' represents the maximum size of
  * the 'dest' buffer.  If the decompressed data fits, its length is returned.  If
@@ -111,6 +122,16 @@ int fz_compress(void *model, const char *source, int source_len, char *dest, int
  * @see fz_compress.
  */
 int fz_decompress(void *model, const char *source, int source_len, char *dest, int dest_capacity);
+
+/*
+ * Attempts to dcompress 'source_len' bytes starting at 'source'.  'dest_writer'
+ * is called with a pointer to the destination buffer and it's length.  The
+ * pointer is valid only for the lifetime of 'dest_writer'.  Returns 0 on
+ * success, non zero if an error occurred.
+ *
+ * @see fz_compress_writer.
+ */
+int fz_decompress_writer(void *model, const char *source, size_t source_len, int (*dest_writer)(const char *buf, size_t len, void *arg), void *arg);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR adds two functions `fz_compress_writer` and `fz_decompress_writer` which mirror `fz_compress` and `fz_decompress` but take a writer function rather than a destination buffer.

Where the original functions take `char *dest, int dest_capacity` and need a preallocated buffer, the new functions take a writer function (`int (*dest_writer)(const char *buf, size_t len, void *arg)`) and an argument for it.

Using these functions it *may* be possible (depending on the use case) to avoid the overhead of a `memcpy`. These functions also remove the wasteful need to call `fz_compress` or `fz_decompress` twice if the destination buffer is too small.