### PR TITLE
Fix compilation error

### DIFF
--- a/cpp/libfz/src/IntSet.h
+++ b/cpp/libfz/src/IntSet.h
@@ -32,7 +32,7 @@ namespace femtozip {
  */
 class IntSet {
 private:
-    static const float load_factor = .7;
+    static constexpr float load_factor = .7;
 
     int *buckets;
     int *bucket_end;


### PR DESCRIPTION
Tried to build on latest Ubuntu, have this error:
```
In file included from DictionaryOptimizer.cpp:33:
IntSet.h:35:24: error: ‘constexpr’ needed for in-class initialization of static data member ‘const float femtozip::IntSet::load_factor’ of non-integral type [-fpermissive]
   35 |     static const float load_factor = .7;
      |                        ^~~~~~~~~~~
```